### PR TITLE
doc: Fix param object table display

### DIFF
--- a/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
+++ b/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
@@ -18,9 +18,9 @@ The image widget is used to display images and supports image rotation.
 ## Create UI widget
 
 ```js
-import { createWidget, widget } from '@zos/ui'
+import { createWidget, widget } from "@zos/ui";
 
-const img = createWidget(widget.IMG, Param)
+const img = createWidget(widget.IMG, Param);
 ```
 
 ## Type
@@ -28,20 +28,20 @@ const img = createWidget(widget.IMG, Param)
 ### Param: object
 
 | Properties         | Description                                                                                                                                                      | Required | Type      |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- | --- |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
 | src                | The path of the image. Reference [folder-structure structure](../../../../../guides/architecture/folder-structure.mdx)                                           | YES      | `string`  |
-| w                  | The width of the widget.If not passed then set the width of the image itself                                                                                  | NO       | `number`  |
-| h                  | The height of the widget.If not passed then set the height of the image itself                                                                                | NO       | `number`  |
-| x                  | The x-axis coordinate of the widget.                                                                                                                          | YES      | `number`  |
-| y                  | The y-axis coordinate of the widget.                                                                                                                          | YES      | `number`  |
+| w                  | The width of the widget.If not passed then set the width of the image itself                                                                                     | NO       | `number`  |
+| h                  | The height of the widget.If not passed then set the height of the image itself                                                                                   | NO       | `number`  |
+| x                  | The x-axis coordinate of the widget.                                                                                                                             | YES      | `number`  |
+| y                  | The y-axis coordinate of the widget.                                                                                                                             | YES      | `number`  |
 | pos_x              | Horizontal offset of the image relative to the widget coordinates.                                                                                               | NO       | `number`  |
 | pos_y              | Vertical offset of the image relative to the widget coordinates.                                                                                                 | NO       | `number`  |
 | angle              | The rotation angle of the picture (the 12-point direction is 0 degrees).                                                                                         | NO       | `number`  |
 | center_x           | The rotation center of the picture.                                                                                                                              | NO       | `number`  |
 | center_y           | The rotation center of the picture.                                                                                                                              | NO       | `number`  |
-| alpha              | Transparency, 0 - 255, default value is 255 for opaque, 0 for full transparency                                                                                  | NO       | `number`  | -   |
-| auto_scale         | Whether the image scales with the widget width and height, the default image area size is the size of the resource file itself                                   | NO       | `boolean` | -   |
-| auto_scale_obj_fit | This field takes effect only when `auto_scale` is `true`, indicating whether the image fills the entire widget area (without maintaining the image aspect ratio) | NO       | `boolean` | -   |
+| alpha              | Transparency, 0 - 255, default value is 255 for opaque, 0 for full transparency                                                                                  | NO       | `number`  |
+| auto_scale         | Whether the image scales with the widget width and height, the default image area size is the size of the resource file itself                                   | NO       | `boolean` |
+| auto_scale_obj_fit | This field takes effect only when `auto_scale` is `true`, indicating whether the image fills the entire widget area (without maintaining the image aspect ratio) | NO       | `boolean` |
 
 ## Image example
 
@@ -56,30 +56,30 @@ const img = createWidget(widget.IMG, Param)
 ## Code example
 
 ```js
-import { createWidget, widget, prop } from '@zos/ui'
+import { createWidget, widget, prop } from "@zos/ui";
 
 Page({
   build() {
     const img = createWidget(widget.IMG, {
       x: 125,
       y: 125,
-      src: 'zeppos.png'
-    })
+      src: "zeppos.png",
+    });
     img.addEventListener(event.CLICK_DOWN, (info) => {
       img.setProperty(prop.MORE, {
-        y: 200
-      })
-    })
-  }
-})
+        y: 200,
+      });
+    });
+  },
+});
 ```
 
 ```js
-import { createWidget, widget, prop } from '@zos/ui'
+import { createWidget, widget, prop } from "@zos/ui";
 
 Page({
   build() {
-    const img_hour = createWidget(widget.IMG)
+    const img_hour = createWidget(widget.IMG);
     img_hour.setProperty(prop.MORE, {
       x: 0,
       y: 0,
@@ -89,9 +89,9 @@ Page({
       pos_y: 50 + 50,
       center_x: 454 / 2,
       center_x: 454 / 2,
-      src: 'hour.png',
-      angle: 30
-    })
-  }
-})
+      src: "hour.png",
+      angle: 30,
+    });
+  },
+});
 ```

--- a/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
+++ b/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
@@ -20,7 +20,7 @@ The image widget is used to display images and supports image rotation.
 ```js
 import { createWidget, widget } from '@zos/ui'
 
-const img = createWidget(widget.IMG, Param);
+const img = createWidget(widget.IMG, Param)
 ```
 
 ## Type

--- a/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
+++ b/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
@@ -18,7 +18,7 @@ The image widget is used to display images and supports image rotation.
 ## Create UI widget
 
 ```js
-import { createWidget, widget } from "@zos/ui";
+import { createWidget, widget } from '@zos/ui';
 
 const img = createWidget(widget.IMG, Param);
 ```
@@ -56,30 +56,30 @@ const img = createWidget(widget.IMG, Param);
 ## Code example
 
 ```js
-import { createWidget, widget, prop } from "@zos/ui";
+import { createWidget, widget, prop } from '@zos/ui';
 
 Page({
   build() {
     const img = createWidget(widget.IMG, {
       x: 125,
       y: 125,
-      src: "zeppos.png",
-    });
+      src: 'zeppos.png'
+    })
     img.addEventListener(event.CLICK_DOWN, (info) => {
       img.setProperty(prop.MORE, {
-        y: 200,
-      });
-    });
-  },
+        y: 200
+      })
+    })
+  }
 });
 ```
 
 ```js
-import { createWidget, widget, prop } from "@zos/ui";
+import { createWidget, widget, prop } from '@zos/ui';
 
 Page({
   build() {
-    const img_hour = createWidget(widget.IMG);
+    const img_hour = createWidget(widget.IMG)
     img_hour.setProperty(prop.MORE, {
       x: 0,
       y: 0,
@@ -89,9 +89,9 @@ Page({
       pos_y: 50 + 50,
       center_x: 454 / 2,
       center_x: 454 / 2,
-      src: "hour.png",
-      angle: 30,
-    });
-  },
-});
+      src: 'hour.png',
+      angle: 30
+    })
+  }
+})
 ```

--- a/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
+++ b/docs/reference/device-app-api/newAPI/ui/widget/IMG.mdx
@@ -18,7 +18,7 @@ The image widget is used to display images and supports image rotation.
 ## Create UI widget
 
 ```js
-import { createWidget, widget } from '@zos/ui';
+import { createWidget, widget } from '@zos/ui'
 
 const img = createWidget(widget.IMG, Param);
 ```
@@ -56,7 +56,7 @@ const img = createWidget(widget.IMG, Param);
 ## Code example
 
 ```js
-import { createWidget, widget, prop } from '@zos/ui';
+import { createWidget, widget, prop } from '@zos/ui'
 
 Page({
   build() {
@@ -71,11 +71,11 @@ Page({
       })
     })
   }
-});
+})
 ```
 
 ```js
-import { createWidget, widget, prop } from '@zos/ui';
+import { createWidget, widget, prop } from '@zos/ui'
 
 Page({
   build() {


### PR DESCRIPTION
Current on IMG.mdx docs
<img width="1531" alt="image" src="https://github.com/zepp-health/zeppos-docs/assets/16449020/40f3c21a-cb24-47bd-ad99-641bc7226078">

updated:

<img width="862" alt="image" src="https://github.com/zepp-health/zeppos-docs/assets/16449020/ed582d60-e8b5-48c8-a37a-77c9539d4c05">
